### PR TITLE
Add 'CASCADE' to all drop tables.

### DIFF
--- a/sqlalchemy_greenplum/dialect.py
+++ b/sqlalchemy_greenplum/dialect.py
@@ -162,6 +162,10 @@ class GreenplumDDLCompiler(PGDDLCompiler):
         text += self._prepared_index_name(index, include_schema=True)
         return text
 
+    def visit_drop_table(self, element):
+        superclass = super(GreenplumDDLCompiler, self)
+        return superclass.visit_drop_table(element) + ' CASCADE'
+
 class GreenplumCompiler(PGCompiler_psycopg2):
     pass
     # def format_from_hint_text(self, sqltext, table, hint, iscrud):


### PR DESCRIPTION
I'm not sure if this is overkill or not. I've never wanted to drop a table, but not wanted to drop cascade a table.

However, this might be plaid specific. Paul thought there was already plaid-specific stuff in sqlalchemy-greenplum, but looking around I don't see any.

If you've got a suggestion for a better way to do this, please let me know.

This is required for rpc.analyze.table.save to work.